### PR TITLE
Fix sorting of versions making RC tags the latest compared to "real" tags

### DIFF
--- a/qompoter.sh
+++ b/qompoter.sh
@@ -943,6 +943,8 @@ downloadPackageFromCp()
  # Select the best version (if variadic version number provided)
   if [ "${packageVersion#*\*}" != "${packageVersion}" ]; then
     logDebug "  Search matching version"
+    # _ (underscore) added at the end of every tag without a hyphen to get "official" tags after alpha/beta/rc tags
+    # .0 added before underscore to make sure that tags with X.Y numbering with a higher Y number get chosen before a X.Y.Z numbering tag
     logTrace $(ls "${requireBasePath}" | sed '/-/!{s/$/.0_/}' | LC_ALL=C sort -V | sed 's/.0_$//') # noquote for oneline
     selectedVersion=$(ls "${requireBasePath}" | sed '/-/!{s/$/.0_/}' | LC_ALL=C sort -V | sed 's/.0_$//' | getBestVersionNumber "$packageVersion")
     if [ -z "${selectedVersion}" ]; then
@@ -1026,6 +1028,8 @@ downloadLibPackage()
   # Select the best version (if variadic version number provided)
   if [ "${packageVersion#*\*}" != "${packageVersion}" ]; then
     logDebug "  Search matching version"
+    # _ (underscore) added at the end of every tag without a hyphen to get "official" tags after alpha/beta/rc tags
+    # .0 added before underscore to make sure that tags with X.Y numbering with a higher Y number get chosen before a X.Y.Z numbering tag
     logTrace $(ls "${requireBasePath}" | sed '/-/!{s/$/.0_/}' | LC_ALL=C sort -V | sed 's/.0_$//' ) # noquote for oneline
     selectedVersion=$(ls "${requireBasePath}" | sed '/-/!{s/$/.0_/}' | LC_ALL=C sort -V | sed 's/.0_$//' | getBestVersionNumber "${packageVersion}")
     if [ -z "${selectedVersion}" ]; then
@@ -1258,6 +1262,8 @@ downloadPackageFromGit()
   if [ "${packageVersion#*\*}" != "${packageVersion}" ]; then
     logDebug "  Search matching version"
     logTrace "git tag --list"
+    # _ (underscore) added at the end of every tag without a hyphen to get "official" tags after alpha/beta/rc tags
+    # .0 added before underscore to make sure that tags with X.Y numbering with a higher Y number get chosen before a X.Y.Z numbering tag
     logGitTrace $(git tag --list | sed '/-/!{s/$/.0_/}' | LC_ALL=C sort -V | sed 's/.0_$//') # noquote for oneline
     local selectedVersion
     selectedVersion=$(git tag --list | sed '/-/!{s/$/.0_/}' | LC_ALL=C sort -V | sed 's/.0_$//' | getBestVersionNumber "${packageVersion}")

--- a/qompoter.sh
+++ b/qompoter.sh
@@ -943,8 +943,8 @@ downloadPackageFromCp()
  # Select the best version (if variadic version number provided)
   if [ "${packageVersion#*\*}" != "${packageVersion}" ]; then
     logDebug "  Search matching version"
-    logTrace $(ls "${requireBasePath}" | LC_ALL=C sort -V) # noquote for oneline
-    selectedVersion=$(ls "${requireBasePath}" | LC_ALL=C sort -V | getBestVersionNumber "$packageVersion")
+    logTrace $(ls "${requireBasePath}" | sed '/-/!{s/$/.0_/}' | LC_ALL=C sort -V | sed 's/.0_$//') # noquote for oneline
+    selectedVersion=$(ls "${requireBasePath}" | sed '/-/!{s/$/.0_/}' | LC_ALL=C sort -V | sed 's/.0_$//' | getBestVersionNumber "$packageVersion")
     if [ -z "${selectedVersion}" ]; then
       echo "  Oups, no matching version for \"${packageVersion}\""
       return 2
@@ -1026,8 +1026,8 @@ downloadLibPackage()
   # Select the best version (if variadic version number provided)
   if [ "${packageVersion#*\*}" != "${packageVersion}" ]; then
     logDebug "  Search matching version"
-    logTrace $(ls "${requireBasePath}" | LC_ALL=C sort -V) # noquote for oneline
-    selectedVersion=$(ls "${requireBasePath}" | LC_ALL=C sort -V | getBestVersionNumber "${packageVersion}")
+    logTrace $(ls "${requireBasePath}" | sed '/-/!{s/$/.0_/}' | LC_ALL=C sort -V | sed 's/.0_$//' ) # noquote for oneline
+    selectedVersion=$(ls "${requireBasePath}" | sed '/-/!{s/$/.0_/}' | LC_ALL=C sort -V | sed 's/.0_$//' | getBestVersionNumber "${packageVersion}")
     if [ -z "${selectedVersion}" ]; then
       echo "  Oups, no matching version for \"${packageVersion}\""
       return 2
@@ -1258,9 +1258,9 @@ downloadPackageFromGit()
   if [ "${packageVersion#*\*}" != "${packageVersion}" ]; then
     logDebug "  Search matching version"
     logTrace "git tag --list"
-    logGitTrace $(git tag --list | LC_ALL=C sort -V) # noquote for oneline
+    logGitTrace $(git tag --list | sed '/-/!{s/$/.0_/}' | LC_ALL=C sort -V | sed 's/.0_$//') # noquote for oneline
     local selectedVersion
-    selectedVersion=$(git tag --list | LC_ALL=C sort -V | getBestVersionNumber "${packageVersion}")
+    selectedVersion=$(git tag --list | sed '/-/!{s/$/.0_/}' | LC_ALL=C sort -V | sed 's/.0_$//' | getBestVersionNumber "${packageVersion}")
     if [ -z "${selectedVersion}" ]; then
       echo "  Oups, no matching version for \"${requireVersion}\""
       cd - > /dev/null 2>&1 || ( echo "  Error: cannot go back to ${currentPath}" ; echo -e "${C_FAIL}FAILURE${C_END}" ; exit -1)

--- a/test/install-action-for-source-git-packages.sh
+++ b/test/install-action-for-source-git-packages.sh
@@ -16,11 +16,11 @@ qompoterVersionStarOrderNaturally='{ "name": "install-git/git", "require": { "fy
 qompoterCommit='{ "name": "install-git/git", "require": { "fylhan/qompoter-test-package4git": "#9504ee4" }, "repositories": { "fylhan/qompoter-test-package4git": "https://github.com" }}'
 QOMPOTER_FILES=("${qompoterBranch}" "${qompoterVersionStar}" "${qompoterVersion}" "${qompoterVersionStarOrderNaturally}" "${qompoterCommit}")
 TEST_CASE_NAMES=("install a git package with given branch" \
-                "install a git package with a given variadic version v1.* -> v1.1-alpha" \
+                "install a git package with a given variadic version v1.* -> v1.1" \
                 "install a git package with a given version" \
                 "install a git package with a given variadic version v2.* -> v2.0.10 (whereas v2.0.1 exists)" \
                 "install a git package with a given commit number")
-TEST_CASE_EXPECTED_RESULTS=("mybranch" "v1.1-alpha" "v1.0" "v2.0.10" "9504ee4")
+TEST_CASE_EXPECTED_RESULTS=("mybranch" "v1.1" "v1.0" "v2.0.10" "9504ee4")
 
 echo "1..$((${#QOMPOTER_FILES[*]}+3))"
 

--- a/test/packages-from-inqlude/source-git-packages.expected
+++ b/test/packages-from-inqlude/source-git-packages.expected
@@ -8,7 +8,7 @@ Qompoter
 
 * kde/bluez-qt v5.24.*
   Downloading sources from Git...
-  Selected version: v5.24.0-rc1
+  Selected version: v5.24.0
   Warning: no 'qompoter.pri' found for this package
   done
 

--- a/test/packages-from-inqlude/source-git-packages.vendor.expected
+++ b/test/packages-from-inqlude/source-git-packages.vendor.expected
@@ -361,6 +361,7 @@ vendor/fylhan
 vendor/fylhan/qompoter.json
 vendor/fylhan/qompoter.pri
 vendor/glc-lib
+vendor/glc-lib/GLC_Triangle
 vendor/glc-lib/LICENSE.LGPL
 vendor/glc-lib/README
 vendor/glc-lib/doc
@@ -383,6 +384,9 @@ vendor/glc-lib/src/examples/example08
 vendor/glc-lib/src/examples/example09
 vendor/glc-lib/src/examples/example10
 vendor/glc-lib/src/examples/example11
+vendor/glc-lib/src/examples/example12
+vendor/glc-lib/src/examples/example13
+vendor/glc-lib/src/examples/example14
 vendor/glc-lib/src/examples/examples.pro
 vendor/glc-lib/src/lib
 vendor/glc-lib/src/lib/3DWidget
@@ -406,6 +410,10 @@ vendor/glc-lib/src/lib/GLC_Circle
 vendor/glc-lib/src/lib/GLC_Cone
 vendor/glc-lib/src/lib/GLC_Context
 vendor/glc-lib/src/lib/GLC_ContextManager
+vendor/glc-lib/src/lib/GLC_CsgHelper
+vendor/glc-lib/src/lib/GLC_CsgLeafNode
+vendor/glc-lib/src/lib/GLC_CsgNode
+vendor/glc-lib/src/lib/GLC_CsgOperatorNode
 vendor/glc-lib/src/lib/GLC_CuttingPlane
 vendor/glc-lib/src/lib/GLC_Cylinder
 vendor/glc-lib/src/lib/GLC_Disc
@@ -422,9 +430,11 @@ vendor/glc-lib/src/lib/GLC_GeomTools
 vendor/glc-lib/src/lib/GLC_Geometry
 vendor/glc-lib/src/lib/GLC_Global
 vendor/glc-lib/src/lib/GLC_Glu
+vendor/glc-lib/src/lib/GLC_Image
 vendor/glc-lib/src/lib/GLC_ImagePlane
 vendor/glc-lib/src/lib/GLC_InputEventInterpreter
 vendor/glc-lib/src/lib/GLC_Interpolator
+vendor/glc-lib/src/lib/GLC_LatheMesh
 vendor/glc-lib/src/lib/GLC_Light
 vendor/glc-lib/src/lib/GLC_Line
 vendor/glc-lib/src/lib/GLC_Line3d
@@ -437,9 +447,13 @@ vendor/glc-lib/src/lib/GLC_MoverController
 vendor/glc-lib/src/lib/GLC_Object
 vendor/glc-lib/src/lib/GLC_Octree
 vendor/glc-lib/src/lib/GLC_OctreeNode
+vendor/glc-lib/src/lib/GLC_OpenGLViewHandler
+vendor/glc-lib/src/lib/GLC_OpenGLViewInterface
+vendor/glc-lib/src/lib/GLC_OpenGLViewWidget
 vendor/glc-lib/src/lib/GLC_OpenGlException
 vendor/glc-lib/src/lib/GLC_PanMover
 vendor/glc-lib/src/lib/GLC_Plane
+vendor/glc-lib/src/lib/GLC_PlaneManipulator
 vendor/glc-lib/src/lib/GLC_Point
 vendor/glc-lib/src/lib/GLC_Point2d
 vendor/glc-lib/src/lib/GLC_Point2df
@@ -448,6 +462,7 @@ vendor/glc-lib/src/lib/GLC_Point3df
 vendor/glc-lib/src/lib/GLC_Point4d
 vendor/glc-lib/src/lib/GLC_PointCloud
 vendor/glc-lib/src/lib/GLC_PointSprite
+vendor/glc-lib/src/lib/GLC_Polygon
 vendor/glc-lib/src/lib/GLC_Polylines
 vendor/glc-lib/src/lib/GLC_PullManipulator
 vendor/glc-lib/src/lib/GLC_QuickCamera
@@ -455,6 +470,7 @@ vendor/glc-lib/src/lib/GLC_QuickItem
 vendor/glc-lib/src/lib/GLC_QuickOccurrence
 vendor/glc-lib/src/lib/GLC_QuickSelection
 vendor/glc-lib/src/lib/GLC_QuickView
+vendor/glc-lib/src/lib/GLC_QuickViewHandler
 vendor/glc-lib/src/lib/GLC_Rectangle
 vendor/glc-lib/src/lib/GLC_RenderProperties
 vendor/glc-lib/src/lib/GLC_RenderState
@@ -477,6 +493,7 @@ vendor/glc-lib/src/lib/GLC_State
 vendor/glc-lib/src/lib/GLC_StructInstance
 vendor/glc-lib/src/lib/GLC_StructOccurrence
 vendor/glc-lib/src/lib/GLC_StructReference
+vendor/glc-lib/src/lib/GLC_Text
 vendor/glc-lib/src/lib/GLC_Texture
 vendor/glc-lib/src/lib/GLC_TraceLog
 vendor/glc-lib/src/lib/GLC_TrackBallMover
@@ -495,6 +512,7 @@ vendor/glc-lib/src/lib/GLC_WorldReaderHandler
 vendor/glc-lib/src/lib/GLC_WorldReaderPlugin
 vendor/glc-lib/src/lib/GLC_WorldTo3ds
 vendor/glc-lib/src/lib/GLC_WorldTo3dxml
+vendor/glc-lib/src/lib/GLC_WorldToCollada
 vendor/glc-lib/src/lib/GLC_ZoomMover
 vendor/glc-lib/src/lib/geometry
 vendor/glc-lib/src/lib/glcXmlUtil
@@ -528,6 +546,8 @@ vendor/glc-lib/src/lib/glc_object.cpp
 vendor/glc-lib/src/lib/glc_object.h
 vendor/glc-lib/src/lib/glc_openglexception.cpp
 vendor/glc-lib/src/lib/glc_openglexception.h
+vendor/glc-lib/src/lib/glc_renderstate.cpp
+vendor/glc-lib/src/lib/glc_renderstate.h
 vendor/glc-lib/src/lib/glc_renderstatistics.cpp
 vendor/glc-lib/src/lib/glc_renderstatistics.h
 vendor/glc-lib/src/lib/glc_selectionevent.cpp

--- a/test/qompoter-repo/cp/fylhan/v1.1.10-RC1/qompoter.json
+++ b/test/qompoter-repo/cp/fylhan/v1.1.10-RC1/qompoter.json
@@ -1,0 +1,10 @@
+{
+	"name": "cp/fylhan",
+	"authors": [
+		{
+			"name": "Olivier Maridat",
+			"company": "Trialog",
+			"homepage": "http://olivier.maridat.com"
+		}
+	]
+}

--- a/test/qompoter-repo/cp/fylhan/v1.1.10-RC1/qompoter.pri
+++ b/test/qompoter-repo/cp/fylhan/v1.1.10-RC1/qompoter.pri
@@ -1,0 +1,7 @@
+fylhan {
+    PCKG_NAME = fylhan
+    DEFINES += QOMP_FYLHAN
+
+    INCLUDEPATH += \
+        $$PWD/$$QOMP_FYLHAN
+}


### PR DESCRIPTION
Before these changes, the sorting mechanism would not work correctly with alpha, beta or release candidate tags. These tags would appear as the "latest" tag meaning that, for example, a v4.0.0-RC1 would be chosen before a v4.0.0 tag.
To fix this, the sorting was done after adding .0_ to all tags without hyphens. By doing so, they would appear after the RC tags since the underscore comes after hyphen when use version sort.

Modifications to the tests were done accordingly.